### PR TITLE
Make user listing work on current ruby

### DIFF
--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -83,7 +83,7 @@ class Puppetfactory  < Sinatra::Base
         users  = {}
 
         # build a quick list of all certificate statuses
-        `/opt/puppet/bin/puppet cert list --all`.each do |line|
+        `/opt/puppet/bin/puppet cert list --all`.split.each do |line|
           status[$2] = $1 if line =~ /^([+-])?.*"([\w\.]*)"/
         end
 


### PR DESCRIPTION
Old ruby would allow you to run `.each` on a string and it would
automatically split on newlines. Current requires you to split yourself.
