### PR TITLE
make the user page fail gracefully

### DIFF
--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -148,7 +148,7 @@ class Puppetfactory  < Sinatra::Base
 
     def load_user(username)
       # Lookup the container by username and convert to json
-      user_container = Docker::Container.get(username).json
+      user_container = Docker::Container.get(username).json rescue {}
 
       user = {}
       certname = "#{username}.#{USERSUFFIX}"


### PR DESCRIPTION
This will make the user page load even when the Docker bit blows up. At most, a single user will be incorrect.
