### PR TITLE
Allow environment creation to be prefixed

### DIFF
--- a/pltraining-puppetfactory/manifests/init.pp
+++ b/pltraining-puppetfactory/manifests/init.pp
@@ -26,6 +26,7 @@ class puppetfactory (
   $docker_group = $puppetfactory::params::docker_group,
 
   $pe = $puppetfactory::params::pe,
+  $prefix = $puppetfactory::params::prefix,
   $map_environments = $puppetfactory::params::map_environments,
 ) inherits puppetfactory::params {
 

--- a/pltraining-puppetfactory/manifests/params.pp
+++ b/pltraining-puppetfactory/manifests/params.pp
@@ -25,5 +25,6 @@ class puppetfactory::params {
   $docker_group = 'docker'
 
   $pe = true
+  $prefix = false
   $map_environments = false
 }

--- a/pltraining-puppetfactory/templates/puppetfactory.yaml.erb
+++ b/pltraining-puppetfactory/templates/puppetfactory.yaml.erb
@@ -1,6 +1,6 @@
 ---
 AUTH_INFO:
-  ca_certificate_path: <%= @ca_certificate_path %> 
+  ca_certificate_path: <%= @ca_certificate_path %>
   certificate_path: <%= @certificate_path %>
   private_key_path: <%= @private_key_path %>
 
@@ -24,4 +24,5 @@ PUPPETCODE: <%= @puppetcode %>
 DOCKER_GROUP: <%= @docker_group %>
 
 PE: <%= @pe %>
+PREFIX: <%= @prefix %>
 MAP_ENVIRONMENTS: <%= @map_environments %>

--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -365,7 +365,7 @@ class Puppetfactory  < Sinatra::Base
 
       group_hash = {
         'name'               => certname,
-        'environment'        => username,
+        'environment'        => environment_name(username),
         'environment_trumps' => true,
         'parent'             => '00000000-0000-4000-8000-000000000000',
         'classes'            => {}
@@ -391,6 +391,14 @@ class Puppetfactory  < Sinatra::Base
       certname = "#{username}.#{USERSUFFIX}"
       output = puppetclassify.groups.get_group_id(certname)
       output != nil ? true : false
+    end
+
+    def environment_name(username)
+      if OPTIONS['PREFIX']
+        "#{username}_production"
+      else
+        username
+      end
     end
 
     def call_hooks(hook_type, username)


### PR DESCRIPTION
If PREFIX is enabled, this will create environments named
"#{username}_production", otherwise, just username.
