### PR TITLE
Feature/separate env and modulepath mapping

### DIFF
--- a/pltraining-puppetfactory/manifests/init.pp
+++ b/pltraining-puppetfactory/manifests/init.pp
@@ -28,6 +28,7 @@ class puppetfactory (
   $pe = $puppetfactory::params::pe,
   $prefix = $puppetfactory::params::prefix,
   $map_environments = $puppetfactory::params::map_environments,
+  $map_modulepath = $puppetfactory::params::map_environments, # maintain backwards compatibility and simplicity
 ) inherits puppetfactory::params {
 
   include puppetfactory::service

--- a/pltraining-puppetfactory/templates/puppetfactory.yaml.erb
+++ b/pltraining-puppetfactory/templates/puppetfactory.yaml.erb
@@ -26,3 +26,4 @@ DOCKER_GROUP: <%= @docker_group %>
 PE: <%= @pe %>
 PREFIX: <%= @prefix %>
 MAP_ENVIRONMENTS: <%= @map_environments %>
+MAP_MODULEPATH: <%= @map_modulepath %>

--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -45,6 +45,8 @@ MASTER_HOSTNAME = `hostname`.strip
 DOCKER_GROUP = OPTIONS['DOCKER_GROUP'] || 'docker'
 
 MAP_ENVIRONMENTS = OPTIONS['MAP_ENVIRONMENTS'] || false
+MAP_MODULEPATH   = OPTIONS['MAP_MODULEPATH']   || MAP_ENVIRONMENTS # maintain backwards compatibility
+
 PE  = OPTIONS['PE'] || true
 
 class Puppetfactory  < Sinatra::Base
@@ -290,7 +292,9 @@ class Puppetfactory  < Sinatra::Base
           # make sure the user and pe-puppet can access all the needful
           FileUtils.chown_R(username, 'pe-puppet', environment)
           FileUtils.chmod(0750, environment)
+        end
 
+        if MAP_MODULEPATH then
           binds.push("#{environment}:/root/puppetcode")
           volumes["/root/puppetcode"] = environment
         end


### PR DESCRIPTION
This allows you to map the modulepath and the environment independently.
It will default to the same as `$map_environment` for backwards
compatibility and to make it simpler to use.

Should be merged after #39
