### PR TITLE
Add simple local/remote CLI

### DIFF
--- a/puppetfactory/bin/puppetfactory
+++ b/puppetfactory/bin/puppetfactory
@@ -2,20 +2,81 @@
 
 require 'rubygems'
 require 'puppetfactory'
+require 'optparse'
 
-opts = {
-        :Port               => 8000,
-        :Host               => '0.0.0.0',
-        :Logger             => WEBrick::Log::new(LOGFILE, WEBrick::Log::DEBUG),
-        :ServerType         => WEBrick::Daemon,
-        :DocumentRoot       => DOCROOT,
-        :SSLEnable          => false,
-#         :SSLVerifyClient    => OpenSSL::SSL::VERIFY_NONE,
-#         :SSLCertificate     => OpenSSL::X509::Certificate.new(  File.open(File.join(CERT_PATH, 'server.crt')).read),
-#         :SSLPrivateKey      => OpenSSL::PKey::RSA.new(          File.open(File.join(CERT_PATH, 'server.key')).read),
-#         :SSLCertName        => [ [ "CN",WEBrick::Utils::getservername ] ]
+NAME = File.basename($PROGRAM_NAME)
+
+options = {}
+optparse = OptionParser.new { |opts|
+  opts.banner = "Usage : #{NAME} [command] [target]
+
+When called with no arguments, this will start the PuppetFactory server.
+You can also pass arguments to invoke CLI commands.
+  * ls | list
+      * List all PuppetFactory users
+  * new |create <username> [password]
+      * Create a new PuppetFactory user with an optional password
+  * remove | delete <username>
+      * Delete a PuppetFactory user
+
+This will send commands to the PuppetFactory server specified in
+/etc/puppetfactory.yaml, defaulting to localhost if unspecified.
+"
+
+  opts.on("-s SERVER", "--server SERVER", "Remote PuppetFactory server.") do |arg|
+    options[:server] = arg
+  end
+
+  opts.on("-d", "--debug", "Display extra debugging information.") do
+    options[:debug] = true
+  end
+
+  opts.separator('')
+
+  opts.on("-h", "--help", "Displays this help") do
+    puts opts
+    exit
+  end
 }
+optparse.parse!
 
-Rack::Handler::WEBrick.run(Puppetfactory, opts) do |server|
-        [:INT, :TERM].each { |sig| trap(sig) { server.stop } }
+# if no arguments, start up the server
+if ARGV.size == 0
+  opts = {
+          :Port               => 8000,
+          :Host               => '0.0.0.0',
+          :Logger             => WEBrick::Log::new(LOGFILE, WEBrick::Log::DEBUG),
+          :ServerType         => WEBrick::Daemon,
+          :DocumentRoot       => DOCROOT,
+          :SSLEnable          => false,
+  #         :SSLVerifyClient    => OpenSSL::SSL::VERIFY_NONE,
+  #         :SSLCertificate     => OpenSSL::X509::Certificate.new(  File.open(File.join(CERT_PATH, 'server.crt')).read),
+  #         :SSLPrivateKey      => OpenSSL::PKey::RSA.new(          File.open(File.join(CERT_PATH, 'server.key')).read),
+  #         :SSLCertName        => [ [ "CN",WEBrick::Utils::getservername ] ]
+  }
+
+  Rack::Handler::WEBrick.run(Puppetfactory, opts) do |server|
+          [:INT, :TERM].each { |sig| trap(sig) { server.stop } }
+  end
+else
+  require 'puppetfactory/cli'
+
+  puppetfactory = Puppetfactory::Cli.new(options)
+
+  command, user, password = ARGV
+  case command
+  when 'ls', 'list'
+    puppetfactory.list
+
+  when 'new', 'create'
+    puppetfactory.create(user, password)
+
+  when 'remove', 'delete'
+    puppetfactory.delete(user)
+
+  else
+    puts "Unknown command: #{command}"
+    puts "Run #{NAME} -h for usage."
+    exit 1
+  end
 end

--- a/puppetfactory/lib/puppetfactory/cli.rb
+++ b/puppetfactory/lib/puppetfactory/cli.rb
@@ -1,0 +1,75 @@
+require 'yaml'
+require 'puppetfactory'
+require 'json'
+require 'httparty'
+
+class Puppetfactory
+  class Cli
+    def initialize(options = {})
+      config = YAML.load_file('/etc/puppetfactory.yaml') rescue nil
+
+      if options[:server]
+        @server = options[:server]
+      elsif config['SERVER']
+        @server = config['SERVER']
+      else
+        @server = 'localhost'
+      end
+      @server = "http://#{@server}" unless @server.start_with? 'http'
+
+      @debug = options[:debug]
+    end
+
+    def list()
+      begin
+        puts ' Username          Sandbox URL                    Certname                 Container | Node Group'
+        response = HTTParty.get("#{@server}/api/users")
+        raise "PuppetFactory service not responding: #{@server}" unless response.code == 200
+
+        JSON.parse(response.body).each do |user, params|
+          container = params['container_status']['Dead'] ? 'X' : '+'
+          nodegroup = params['node_group_status']        ? '+' : 'X'
+          printf("%-16s  #{@server}:%5s  %-25s      %1s        %1s\n", user, params['port'], params['certname'], container, nodegroup)
+        end
+      rescue => e
+        puts "API error listing users: #{e.message}"
+        puts e.backtrace if @debug
+      end
+    end
+
+    def create(user, password)
+      begin
+        params = {
+          body: {
+            username: user,
+            password: password
+          }
+        }
+        response = HTTParty.post("#{@server}/api/users", params)
+        raise "PuppetFactory error: #{response.body}" unless response.code == 200
+
+        puts "User #{user} created."
+      rescue => e
+        puts "API error creating user #{user}: #{e.message}"
+        puts e.backtrace if @debug
+      end
+    end
+
+    def delete(user)
+      begin
+        response = HTTParty.delete("#{@server}/api/users/#{user}")
+        raise "No such user" unless response.code == 200
+
+        puts "User #{user} deleted."
+      rescue => e
+        puts "API error deleting user #{user}: #{e.message}"
+        puts e.backtrace if @debug
+      end
+    end
+
+    def test()
+      require 'pry'
+      binding.pry
+    end
+  end
+end

--- a/puppetfactory/puppetfactory.gemspec
+++ b/puppetfactory/puppetfactory.gemspec
@@ -24,12 +24,13 @@ Gem::Specification.new do |s|
   s.add_dependency      "json_pure"
   s.add_dependency      "puppetclassify", ">= 0.1.0"
   s.add_dependency      "docker-api"
+  s.add_dependency      "httparty"
 
   s.description       = <<-desc
-  Puppetfactory creates a Puppet Enterprise infrastructure on the classroom server. 
+  Puppetfactory creates a Puppet Enterprise infrastructure on the classroom server.
   Each student has a container for Puppet code and configuration linked to their
-  environment on the master.  The containers are built on docker and duplicate most 
-  of the behavior of a full VM or bare-metal system.  The classroom server will also 
+  environment on the master.  The containers are built on docker and duplicate most
+  of the behavior of a full VM or bare-metal system.  The classroom server will also
   be running the unmodified Puppet Enterprise Console with an account for each student.
   desc
 end


### PR DESCRIPTION
This just adds a handful of quick commands to list, add, remove users.
It uses the REST API, which means that this can be run from the
puppetfactory machine itself (defaults to sending commands to localhost)
or from any machine which can reach it.

The REST API is terrifyingly unsecured and that needs to be fixed soon.
