### PR TITLE
Update PuppetFactory to work on ec2 nodes

### DIFF
--- a/pltraining-puppetfactory/files/default.conf
+++ b/pltraining-puppetfactory/files/default.conf
@@ -5,8 +5,9 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
     }
-    
+
     location /shellinabox {
       proxy_pass http://127.0.0.1:4200;
     }

--- a/pltraining-puppetfactory/manifests/init.pp
+++ b/pltraining-puppetfactory/manifests/init.pp
@@ -27,6 +27,8 @@ class puppetfactory (
 
   $docker_group = $puppetfactory::params::docker_group,
 
+  $manage_selinux = $puppetfactory::params::manage_selinux,
+
   $pe = $puppetfactory::params::pe,
   $prefix = $puppetfactory::params::prefix,
   $map_environments = $puppetfactory::params::map_environments,
@@ -36,8 +38,11 @@ class puppetfactory (
   include puppetfactory::service
   include puppetfactory::shellinabox
   include puppetfactory::dockerenv
-  include puppetfactory::proxy
   include epel
+
+  class { 'puppetfactory::proxy':
+     manage_selinux => $manage_selinux,
+  }
 
   unless $pe {
     file { ["${codedir}/environments","${codedir}/environments/production"]:,

--- a/pltraining-puppetfactory/manifests/params.pp
+++ b/pltraining-puppetfactory/manifests/params.pp
@@ -25,6 +25,12 @@ class puppetfactory::params {
 
   $docker_group = 'docker'
 
+  # support for old facter versions
+  $manage_selinux = $::os['selinux'] ? {
+    undef   => $::selinux,
+    default => $::os['selinux']['enabled'],
+  }
+
   $pe = true
   $prefix = false
   $map_environments = false

--- a/pltraining-puppetfactory/manifests/proxy.pp
+++ b/pltraining-puppetfactory/manifests/proxy.pp
@@ -1,5 +1,7 @@
 # Use nginx to create a reverse proxy
-class puppetfactory::proxy {
+class puppetfactory::proxy (
+  $manage_selinux = $puppetfactory::params::manage_selinux,
+) inherits puppetfactory::params {
   package {'nginx':
     ensure => present,
   }
@@ -18,5 +20,13 @@ class puppetfactory::proxy {
   service {'nginx':
     ensure  => running,
     require => [File['/etc/nginx/conf.d/default.conf'],File['/etc/nginx/nginx.conf']],
+  }
+
+  # This will allow the nginx proxy rules to work with selinux enabled
+  if $manage_selinux {
+    selboolean { 'httpd_can_network_connect':
+      value      => 'on',
+      persistent => true,
+    }
   }
 }

--- a/puppetfactory/views/home.erb
+++ b/puppetfactory/views/home.erb
@@ -9,12 +9,12 @@
 </p>
 
 <p>
-  The sandbox provided for each student is a container based node.  This means 
+  The sandbox provided for each student is a container based node.  This means
   that most actions will work the same as in a full node. Because the container
   does not have a full init system, service actions may not work as expected.
   Each student's shell account on the master is redirected to the root account of
-  their personalized container. Students can interact with system resources such 
-  as hosts, users, and packages. During the course, the instructor will describe 
+  their personalized container. Students can interact with system resources such
+  as hosts, users, and packages. During the course, the instructor will describe
   Puppet's Resource Abstraction Layer that makes this possible.  Each container
   also has a port 80 redirected to a port on the master, so that students can
   start a web server inside their sandbox environment.
@@ -27,7 +27,7 @@
 <ol>
   <li>First create your account on the Users tab.</li>
   <li>Log in to your sandbox following the directions on the SSH Login tab.</li>
-  <li>Log in to the <a href="https://<%= Socket.ip_address_list[1].ip_address %>" target="_console">Puppet Enterprise Console</a></li>
+  <li>Log in to the <a href="https://<%= request.host %>" target="_console">Puppet Enterprise Console</a></li>
 <ol>
 
 

--- a/puppetfactory/views/login.erb
+++ b/puppetfactory/views/login.erb
@@ -18,7 +18,7 @@
         Built-in to Mac OSX and Linux:
         <ol>
           <li>Start Terminal.app or any terminal emulator to get to the command line</li>
-          <li>Run <code>ssh <%= Socket.ip_address_list[1].ip_address %></code></li>
+          <li>Run <code>ssh <%= request.host %></code></li>
         </ol>
       </li>
       <li>


### PR DESCRIPTION
This will:
- Set Selinux to allow nginx to proxy if it's enabled.
- Set nginx proxy header so request.host behaves properly.
- Use request.host when constructing addresses.
