### PR TITLE
Correct typo and don't assume fqdn

### DIFF
--- a/pltraining-puppetfactory/manifests/dockerenv.pp
+++ b/pltraining-puppetfactory/manifests/dockerenv.pp
@@ -1,7 +1,11 @@
-class puppetfactory::dockerenv inherits puppetfactory::params{
+class puppetfactory::dockerenv {
+  assert_private('This class should not be called directly')
+
+  $puppetmaster = $puppetfactory::puppetmaster
+
   include docker
-  
-  if $pe {
+
+  if $puppetfactory::pe {
     include pe_repo::platform::ubuntu_1404_amd64
   }
 
@@ -45,12 +49,12 @@ class puppetfactory::dockerenv inherits puppetfactory::params{
 
 
   file { '/var/run/docker.sock':
-    group   => $docker_group,
+    group   => $puppetfactory::docker_group,
     mode    => '0664',
     require => [Class['docker'],Group['docker']],
   }
 
-  group { $docker_group:
+  group { $puppetfactory::docker_group:
     ensure => present,
   }
 }

--- a/pltraining-puppetfactory/templates/centos.dockerfile.erb
+++ b/pltraining-puppetfactory/templates/centos.dockerfile.erb
@@ -5,12 +5,10 @@ MAINTAINER Josh Samuelson <js@puppetlabs.com>
 ENV HOME /root/
 ENV TERM xterm
 RUN yum -y install sudo tar dmidecode which logrotate cyrus-sasl libxslt cronie pciutils git rubygems vim tree csh zsh ntpdate
-RUN gem install multipart-post -v 1.2.0
-RUN gem install r10k
 RUN rm /etc/yum.repos.d/CentOS*
 ADD base_local.repo /etc/yum.repos.d/base_local.repo
 ADD epel_local.repo /etc/yum.repos.d/epel_local.repo
 ADD updates_local.repo /etc/yum.repos.d/updates_local.repo
-RUN echo 'if ! hash puppet; then curl -k https://<%= @fqdn %>:8140/packages/current/install.bash | sudo bash; puppet apply -e "include course_selector"; fi' >> /root/.bash
+RUN echo 'if ! hash puppet; then curl -k https://<%= @puppetmaster %>:8140/packages/current/install.bash | sudo bash; puppet apply -e "include course_selector"; fi' >> /root/.bash
 RUN mkdir -p /etc/puppetlabs/code/modules
 RUN git clone https://github.com/puppetlabs/pltraining-course_selector /etc/puppetlabs/code/modules/course_selector

--- a/pltraining-puppetfactory/templates/ubuntu.dockerfile.erb
+++ b/pltraining-puppetfactory/templates/ubuntu.dockerfile.erb
@@ -6,6 +6,4 @@ ENV HOME /root/
 ENV TERM xterm
 RUN apt-get update
 RUN apt-get --assume-yes install ruby ntp
-RUN gem install multipart-post -v 1.2.0
-RUN gem install r10k
-RUN echo 'if ! hash puppet; then curl -k https://<%= @fqdn %>:8140/packages/current/install.bash | sudo bash; fi' >> /root/.bashrc
+RUN echo 'if ! hash puppet; then curl -k https://<%= @puppetmaster %>:8140/packages/current/install.bash | sudo bash; fi' >> /root/.bashrc


### PR DESCRIPTION
This puts the shell initialization in .bashrc and eliminates the
assumption that we'll be using fqdn always. (for ec2 support)
