### PR TITLE
Add a simple spec helper for rspec-puppet tests

### DIFF
--- a/puppetfactory/lib/puppetfactory/dashboard/spec_helper.rb
+++ b/puppetfactory/lib/puppetfactory/dashboard/spec_helper.rb
@@ -5,7 +5,7 @@ username = ENV['TARGET_HOST']
 RSpec.configure do |c|
   c.environmentpath = "/etc/puppetlabs/code/environments"
   c.module_path     = "/etc/puppetlabs/code/environments/#{username}/modules"
-  c.manifest_dir    = "/etc/puppetlabs/code/environments/#{username}/manifests"
+  c.manifest        = "/etc/puppetlabs/code/environments/#{username}/manifests"
 
   # Adds to the built in defaults from rspec-puppet
   c.default_facts = {


### PR DESCRIPTION
This helper allows us to use rspec-puppet tests to validate code in
student's live environments. Be aware that this depends on a patch
to fix a hardcoded default in rspec-puppet. @adrienthebo is working on a
better PR for upstream.

https://gist.github.com/binford2k/060cc33f9f0f9b7a0e69
