### PR TITLE
Expose $session_id as a parameter

### DIFF
--- a/pltraining-puppetfactory/manifests/init.pp
+++ b/pltraining-puppetfactory/manifests/init.pp
@@ -14,6 +14,7 @@ class puppetfactory (
   $cert_path           = $puppetfactory::params::cert_path,
   $user                = $puppetfactory::params::user,
   $password            = $puppetfactory::params::password,
+  $session_id          = $puppetfactory::params::session_id,
 
   $confdir             = $puppetfactory::params::confdir,
   $codedir             = $puppetfactory::params::codedir,

--- a/pltraining-puppetfactory/manifests/params.pp
+++ b/pltraining-puppetfactory/manifests/params.pp
@@ -9,11 +9,12 @@ class puppetfactory::params {
   $puppet = '/opt/puppetlabs/puppet/bin/puppet'
   $rake   = '/opt/puppetlabs/puppet/bin/rake'
 
-  $docroot   = '/opt/puppetfactory'
-  $logfile   = '/var/log/puppetfactory'
-  $cert_path = 'certs'
-  $user      = 'admin'
-  $password  = 'admin'
+  $docroot    = '/opt/puppetfactory'
+  $logfile    = '/var/log/puppetfactory'
+  $cert_path  = 'certs'
+  $user       = 'admin'
+  $password   = 'admin'
+  $session_id = '12345'
 
   $confdir = '/etc/puppetlabs/puppet'
   $codedir = '/etc/puppetlabs/code'

--- a/pltraining-puppetfactory/manifests/profile/appropriate_module.pp
+++ b/pltraining-puppetfactory/manifests/profile/appropriate_module.pp
@@ -1,9 +1,12 @@
-class puppetfactory::profile::appropriate_module {
+class puppetfactory::profile::appropriate_module (
+  $session_id = $puppetfactory::params::session_id,
+) inherits puppetfactory::params {
   # Classroom for Appropriate Module Design course
   class { 'puppetfactory':
     # Put students' puppetcode directories somewhere obvious
     puppetcode       => '/root/puppetcode',
     map_environments => true,
     container_name   => 'centosagent',
+    session_id       => $session_id,
   }
 }

--- a/pltraining-puppetfactory/manifests/profile/code_management.pp
+++ b/pltraining-puppetfactory/manifests/profile/code_management.pp
@@ -1,8 +1,11 @@
-class puppetfactory::profile::code_management {
+class puppetfactory::profile::code_management (
+  $session_id = $puppetfactory::params::session_id,
+) inherits puppetfactory::params {
   # Classroom for the codemanagement course
   class { 'puppetfactory':
     # Put students' puppetcode directories somewhere less distracting
     puppetcode => '/var/opt/puppetcode',
+    session_id       => $session_id,
   }
 
   class { 'r10k':

--- a/pltraining-puppetfactory/manifests/profile/first_module.pp
+++ b/pltraining-puppetfactory/manifests/profile/first_module.pp
@@ -1,9 +1,12 @@
-class puppetfactory::profile::first_module {
+class puppetfactory::profile::first_module (
+  $session_id = $puppetfactory::params::session_id,
+) inherits puppetfactory::params {
   # Classroom for First Module
   class { 'puppetfactory':
     # Put students' puppetcode directories somewhere obvious
     puppetcode       => '/var/puppetcode',
     map_environments => true,
     container_name   => 'centosagent',
+    session_id       => $session_id,
   }
 }

--- a/pltraining-puppetfactory/manifests/profile/fundamentals.pp
+++ b/pltraining-puppetfactory/manifests/profile/fundamentals.pp
@@ -1,4 +1,6 @@
-class puppetfactory::profile::fundamentals {
+class puppetfactory::profile::fundamentals (
+  $session_id = $puppetfactory::params::session_id,
+) inherits puppetfactory::params {
 
   ensure_packages('gcc', {
     before => Package['puppetfactory']
@@ -8,6 +10,7 @@ class puppetfactory::profile::fundamentals {
     prefix           => true,
     map_environments => true,
     map_modulepath   => false,
+    session_id       => $session_id,
   }
 
   File {

--- a/pltraining-puppetfactory/manifests/profile/intro.pp
+++ b/pltraining-puppetfactory/manifests/profile/intro.pp
@@ -1,9 +1,12 @@
-class puppetfactory::profile::intro {
+class puppetfactory::profile::intro (
+  $session_id = $puppetfactory::params::session_id,
+) inherits puppetfactory::params {
   # Classroom for Intro to puppet course
   class { 'puppetfactory':
     # Put students' puppetcode directories somewhere obvious
     puppetcode       => '/root/puppetcode',
     map_environments => true,
     container_name   => 'centosagent',
+    session_id       => $session_id,
   }
 }

--- a/pltraining-puppetfactory/manifests/profile/parser.pp
+++ b/pltraining-puppetfactory/manifests/profile/parser.pp
@@ -1,8 +1,11 @@
-class puppetfactory::profile::parser {
+class puppetfactory::profile::parser (
+  $session_id = $puppetfactory::params::session_id,
+) inherits puppetfactory::params {
   # Classroom for the parser course
   class { 'puppetfactory':
     # Put students' puppetcode directories somewhere less distracting
     puppetcode       => '/var/opt/puppetcode',
     map_environments => false,
+    session_id       => $session_id,
   }
 }

--- a/pltraining-puppetfactory/templates/puppetfactory.yaml.erb
+++ b/pltraining-puppetfactory/templates/puppetfactory.yaml.erb
@@ -14,7 +14,9 @@ DOCROOT: <%= @docroot %>
 LOGFILE: <%= @logfile %>
 CERT_PATH: <%= @cert_path %>
 USER: <%= @user %>
-PASSWORD: <%= @password %>
+PASSWORD: "<%= @password %>"
+SESSION: "<%= @session_id %>"
+
 CONTAINER_NAME: <%= @container_name %>
 
 CONFDIR: <%= @confdir %>


### PR DESCRIPTION
This allows you to classify the Puppetfactory with a session ID for each
delivery, if/when we choose. Also adds a few quotes to the yaml file to
ensure they're strings. Until I refactor that whole biz, at least.
