### PR TITLE
Adds a link to the users's current test

### DIFF
--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -124,17 +124,12 @@ class Puppetfactory < Sinatra::Base
     erb :dashboard
   end
 
-  get '/dashboard/details/:user/:result' do |user, result|
+  get '/dashboard/details/:user' do |user|
+    get_user_test_html(user, @@current_test)
+  end
 
-    begin
-    if result == 'summary'
-      File.read("#{DASHBOARD}/output/html/#{user}.html")
-    else
-      File.read("#{DASHBOARD}/output/html/#{result}/#{user}.html")
-    end
-    rescue Errno::ENOENT
-      'No results found'
-    end
+  get '/dashboard/details/:user/:result' do |user, result|
+    get_user_test_html(user, result)
   end
 
   get '/dashboard/update' do
@@ -625,6 +620,18 @@ class Puppetfactory < Sinatra::Base
 
     def get_test_data(path)
       JSON.parse(File.read("#{path}/output/summary.json")) rescue {}
+    end
+
+    def get_user_test_html(user, result)
+      begin
+      if result == 'summary'
+        File.read("#{DASHBOARD}/output/html/#{user}.html")
+      else
+        File.read("#{DASHBOARD}/output/html/#{result}/#{user}.html")
+      end
+      rescue Errno::ENOENT
+        'No results found'
+      end
     end
 
     def test_completion(data)

--- a/puppetfactory/public/dashboard.js
+++ b/puppetfactory/public/dashboard.js
@@ -29,7 +29,7 @@ $(document).ready(function(){
     }
     else {
       $('.progressbar').hide();
-      $('.progressbar.'+selected).show();
+      if(selected) { $('.progressbar.'+selected).show(); }
     }
 
     return selected;

--- a/puppetfactory/views/users.erb
+++ b/puppetfactory/views/users.erb
@@ -20,6 +20,7 @@
     <tr><th class="header">Sandbox URL:</th> <td><a href="/port/<%= @current[:port] %>/"><%= @current[:url] %></a></td></tr>
     <tr><th class="header">Container:</th>   <td><%= @current[:container_status]['Description'] %></td></tr>
     <tr><th class="header">Node Group:</th>  <td><a href="<%= @current[:node_group_url] %>" target="_console">Console login</a></td></tr>
+    <tr><th class="header">Spec Tests:</th>  <td><a href="/dashboard/details/<%= @current[:username] %>" target="_results">results</a> <small>(may not always be available)</small></td></tr>
   </table>
 <% end %>
   <h2>All Users</h2>


### PR DESCRIPTION
This just puts a link in the student area to the HTML copy of their
current Rspec test output. It's not foolproof, because it depends on the
instructor to remember to update the current running test. If they leave
it on 'summary' then the output is overwhelming.

Ideas for a better UX?
