### PR TITLE
Account for environment prefixes

### DIFF
--- a/puppetfactory/lib/puppetfactory/dashboard/spec_helper.rb
+++ b/puppetfactory/lib/puppetfactory/dashboard/spec_helper.rb
@@ -2,10 +2,18 @@ require 'rspec-puppet'
 # we can't use psh, because it declares things that conflict with serverspec
 
 username = ENV['TARGET_HOST']
+environmentpath = "/etc/puppetlabs/code/environments"
+
+if File.directory? "#{environmentpath}/#{username}_production"
+  environment = "#{username}_production"
+else
+  environment = username
+end
+
 RSpec.configure do |c|
-  c.environmentpath = "/etc/puppetlabs/code/environments"
-  c.module_path     = "/etc/puppetlabs/code/environments/#{username}/modules"
-  c.manifest        = "/etc/puppetlabs/code/environments/#{username}/manifests"
+  c.environmentpath = environmentpath
+  c.module_path     = "#{environmentpath}/#{environment}/modules"
+  c.manifest        = "#{environmentpath}/#{environment}/manifests"
 
   # Adds to the built in defaults from rspec-puppet
   c.default_facts = {


### PR DESCRIPTION
This will simply check to see if a prefixed environment exists for that
user and use it if so.
