### PR TITLE
Catch nils from Docker

### DIFF
--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -465,6 +465,8 @@ class Puppetfactory < Sinatra::Base
     end
 
     def massage_container_state(state)
+      return {'Description' => 'No container.'} if state.nil?
+      
       if state['OOMKilled']
         state['Description'] = 'Halted because host machine is out of memory.'
       elsif state['Restarting']


### PR DESCRIPTION
Docker apparently returns nil now instead of raising an exception.
