### PR TITLE
Enforce startup order

### DIFF
--- a/pltraining-puppetfactory/manifests/service.pp
+++ b/pltraining-puppetfactory/manifests/service.pp
@@ -34,5 +34,6 @@ class puppetfactory::service {
     ensure    => running,
     enable    => true,
     subscribe => Package['puppetfactory'],
+    require   => Class['docker'], # I don't like this coupling, but it's a reflection of reality
   }
 }


### PR DESCRIPTION
This starts Puppetfactory after Docker has been installed. This ensures
that the docker0 interface actually exists.

TRAINTECH-314 #resolved #time 30m
