### PR TITLE
psh & rspec-puppet need the puppet gem

### DIFF
--- a/pltraining-puppetfactory/manifests/profile/fundamentals.pp
+++ b/pltraining-puppetfactory/manifests/profile/fundamentals.pp
@@ -15,6 +15,14 @@ class puppetfactory::profile::fundamentals (
   package { ['serverspec', 'puppetlabs_spec_helper']:
     ensure   => present,
     provider => gem,
+    require  => Package['puppet'],
+  }
+
+  # lol, this is great.
+  package { 'puppet':
+    ensure          => present,
+    provider        => gem,
+    install_options => { '--bindir' => '/tmp' },
   }
 
   class { 'puppetfactory::profile::showoff':


### PR DESCRIPTION
But we have to futz its install because it conflicts with the symlinks
in `/usr/local/bin`.
