### PR TITLE
Adding PDF generation to puppetfactory stack

### DIFF
--- a/pltraining-puppetfactory/manifests/profile/fundamentals.pp
+++ b/pltraining-puppetfactory/manifests/profile/fundamentals.pp
@@ -26,7 +26,8 @@ class puppetfactory::profile::fundamentals (
   }
 
   class { 'puppetfactory::profile::showoff':
-    preso  => 'fundamentals',
+    preso    => 'fundamentals',
+    password => $session_id,
   }
 
   class { 'puppetfactory':

--- a/pltraining-puppetfactory/manifests/profile/pdf_stack.pp
+++ b/pltraining-puppetfactory/manifests/profile/pdf_stack.pp
@@ -1,0 +1,39 @@
+class puppetfactory::profile::pdf_stack {
+  yumrepo { 'robert-gcj':
+    ensure              => 'present',
+    baseurl             => 'https://copr-be.cloud.fedoraproject.org/results/robert/gcj/epel-7-$basearch/',
+    descr               => 'Copr repo for gcj owned by robert',
+    enabled             => '1',
+    gpgcheck            => '1',
+    gpgkey              => 'https://copr-be.cloud.fedoraproject.org/results/robert/gcj/pubkey.gpg',
+    skip_if_unavailable => 'True',
+  }
+
+  yumrepo { 'robert-pdftk':
+    ensure              => 'present',
+    baseurl             => 'https://copr-be.cloud.fedoraproject.org/results/robert/pdftk/epel-7-$basearch/',
+    descr               => 'Copr repo for pdftk owned by robert',
+    enabled             => '1',
+    gpgcheck            => '1',
+    gpgkey              => 'https://copr-be.cloud.fedoraproject.org/results/robert/pdftk/pubkey.gpg',
+    skip_if_unavailable => 'True',
+    require             => Yumrepo['robert-gcj'],
+  }
+
+  package { ['wkhtmltopdf', 'pdftk']:
+    ensure  => present,
+    require => Yumrepo['robert-pdftk'],
+  }
+
+  $fonts = [
+    'ucs-miscfixed-fonts.noarch',
+    'xorg-x11-fonts-75dpi.noarch',
+    'xorg-x11-fonts-Type1.noarch',
+    'open-sans-fonts.noarch',
+  ]
+
+  package { $fonts:
+    ensure => present,
+  }
+
+}


### PR DESCRIPTION
This is almost complete, but not quite. The centos wkhtmltopdf package
that will be installed is NOT using patched QT, so much of the
functionality we depend on isn't available. For example, print media.

Building and installing an updated package is trivial, but I don't know
where/how it belongs in our stack. I'd much prefer to find an
epel/copr/something package!

``` bash
curl -O http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
tar -xvf wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
fpm -s dir -t rpm -n wkhtmltopdf -v 0.12.3 --prefix /usr -C wkhtmltox .
```

TRAINTECH-353 #time 5h
