### PR TITLE
Use systemd properly

### DIFF
--- a/pltraining-puppetfactory/manifests/wetty.pp
+++ b/pltraining-puppetfactory/manifests/wetty.pp
@@ -22,7 +22,7 @@ class puppetfactory::wetty {
     ensure    => 'running',
     enable    => true,
     require   => Exec['npm -g install wetty'],
-    subscribe => File['/etc/systemd/systemd/wetty.service'],
+    subscribe => File['/etc/systemd/system/wetty.service'],
   }
 
   if $puppetfactory::manage_selinux {


### PR DESCRIPTION
This was putting the systemd file into /etc/init.d.  Now it's doing the proper thing.
