### PR TITLE
Add the wreckit module

### DIFF
--- a/pltraining-puppetfactory/metadata.json
+++ b/pltraining-puppetfactory/metadata.json
@@ -38,6 +38,7 @@
     {"name":"pltraining/showoff",                "version_requirement":">= 0.0.1"},
     {"name":"stahnma/epel",                      "version_requirement":">= 1.0.2"},
     {"name":"zack/r10k"},
-    {"name":"nanliu/staging"}
+    {"name":"nanliu/staging"},
+    {"name":"binford2k/wreckit"}
   ]
 }


### PR DESCRIPTION
This module is like a chaos monkey. It causes random-ish errors for students to troubleshoot and fix. We want it installed into the global modulepath so the students can't cheat by reading the source.

It's currently only used in Puppetize, but might be used in other courses eventually.
