### PR TITLE
Drop the "Labs" - Rebrand

### DIFF
--- a/pltraining-puppetfactory/metadata.json
+++ b/pltraining-puppetfactory/metadata.json
@@ -18,7 +18,7 @@
   "name": "pltraining-puppetfactory",
   "version": "0.4.13",
   "author": "pltraining",
-  "summary": "Manages Puppet Labs training classroom environments",
+  "summary": "Manages Puppet training classroom environments",
   "license": "Apache 2.0",
   "source": "https://github.com/puppetlabs/puppetfactory",
   "project_page": "https://github.com/puppetlabs/puppetfactory",

--- a/puppetfactory/views/index.erb
+++ b/puppetfactory/views/index.erb
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Puppet Labs Training Classroom Manager</title>
+    <title>Puppet Training Classroom Manager</title>
     <link rel="stylesheet" type="text/css" href="jquery-ui.css" media="all" />
     <link rel="stylesheet" type="text/css" href="style.css" />
     <script type="text/javascript" src="jquery.js"></script>
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="jquery.activity-indicator-1.0.0.min.js"></script>
 </head>
 <body>
-    <h1>Puppet Labs Training Classroom Manager</h1>
+    <h1>Puppet Training Classroom Manager</h1>
     <% unless privileged? %><a href="/login" id="login">Admin Login</a><% end %>
     <div id="tabs">
       <ul>


### PR DESCRIPTION
The displayed page used to say "Puppet Labs" prior to this commit.
