### PR TITLE
Stop managing puppetclassify dependency

### DIFF
--- a/pltraining-puppetfactory/manifests/service.pp
+++ b/pltraining-puppetfactory/manifests/service.pp
@@ -7,12 +7,6 @@ class puppetfactory::service {
     source  => 'puppet:///modules/puppetfactory/puppetfactory-0.3.10.gem'
   }
 
-  package { 'puppetclassify':
-    ensure   => present,
-    provider => gem,
-    before   => Package['puppetfactory'],
-  }
-
   package { 'puppetfactory':
     ensure   => present,
     provider => gem,


### PR DESCRIPTION
This is managed by the classroom module now.
