### PR TITLE
full path so it doesn't redirect

### DIFF
--- a/puppetfactory/views/shell.erb
+++ b/puppetfactory/views/shell.erb
@@ -6,7 +6,7 @@
     you created.
   </p>
   <p>
-    <iframe id="console" src="/abalone"></iframe>
+    <iframe id="console" src="/abalone/"></iframe>
   </p>
   <div id="alternate" title="Alternate Login Methods">
     <p>


### PR DESCRIPTION
when used on skytap with a proxy of a proxy of a proxy, it loses the port number when it redirects to include the trailing slash.
