### PR TITLE
Use an actual shell instead of a .bashrc

### DIFF
--- a/pltraining-puppetfactory/files/dockershell
+++ b/pltraining-puppetfactory/files/dockershell
@@ -1,0 +1,4 @@
+#! /bin/ruby
+require 'etc'
+username = Etc.getpwuid(Process.euid).name
+exec("docker exec -it #{username} su -")

--- a/pltraining-puppetfactory/manifests/dockerenv.pp
+++ b/pltraining-puppetfactory/manifests/dockerenv.pp
@@ -65,4 +65,19 @@ class puppetfactory::dockerenv {
   group { $puppetfactory::docker_group:
     ensure => present,
   }
+
+  # set up the shell expected by Puppetfactory
+  file { '/usr/bin/dockershell':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/puppetfactory/dockershell',
+  }
+
+  file_line { 'dockershell':
+    ensure => present,
+    path   => '/etc/shells',
+    line   => '/usr/bin/dockershell',
+  }
 }

--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -357,7 +357,7 @@ class Puppetfactory < Sinatra::Base
     def add_system_user(username, password)
       # ssh login user
       crypted = password.crypt("$5$a1")
-      success = system('adduser', username, '-p', crypted, '-G', "pe-puppet,puppetfactory,#{DOCKER_GROUP}", '-m')
+      success = system('adduser', username, '-p', crypted, '-G', "pe-puppet,puppetfactory,#{DOCKER_GROUP}", '--shell', '/usr/bin/dockershell')
 
       raise "Could not create system user #{username}: #{output}" unless success
       "System user #{username} created successfully"
@@ -498,15 +498,8 @@ class Puppetfactory < Sinatra::Base
           "Name" => "#{username}"
         )
 
-        # Set container name to username
+        # Set container name to username so dockershell can connect to it
         container.rename(username)
-
-        # Set default login to attach to container
-        File.open("/home/#{username}/.bashrc", 'w') do |bashrc|
-          bashrc.puts "docker exec -it #{container.id} su -"
-          bashrc.puts "exit 0"
-        end
-
 
         # Start container and copy puppet.conf in place
         container.start


### PR DESCRIPTION
This makes login more reliable and doesn't leave an extra bash lying
around for each login. It also means that login FAILS instead of just
leaving the user logged in to the master in case something goes wrong.

This also has the benefit that you no longer need a real home directory
if you want to investigate other options for mapping the puppetcode
directory. It works just fine with the user's home set to /tmp.

TRAINTECH-687 #resolved #time 15m
