### PR TITLE
Actually remove containers when requested

### DIFF
--- a/puppetfactory/lib/puppetfactory.rb
+++ b/puppetfactory/lib/puppetfactory.rb
@@ -524,7 +524,6 @@ class Puppetfactory < Sinatra::Base
     def remove_container(username)
       begin
         remove_init_scripts(username)
-        remove_node_group(username)
         remove_certificate(username)
         remove_environment(username)
 
@@ -595,6 +594,7 @@ class Puppetfactory < Sinatra::Base
     end
 
     def remove_init_scripts(username)
+      service_file = "/etc/systemd/system/docker-#{username}.service"
       system('chkconfig', "docker-#{username}", 'off')
       FileUtils.rm(service_file)
     end


### PR DESCRIPTION
Prior to this, containers did not get removed, which meant that users had conflicting port assignment and that repairing accounts to give them privileged status did not actually work properly.

Also, `remove_node_group()` doesn't belong here, especially since it's called somewhere else.
