### PR TITLE
This enforces the separation between staging & live

### DIFF
--- a/pltraining-puppetfactory/manifests/init.pp
+++ b/pltraining-puppetfactory/manifests/init.pp
@@ -3,6 +3,7 @@ class puppetfactory (
   Boolean $manage_selinux = $puppetfactory::params::manage_selinux,
   Boolean $autosign       = $puppetfactory::params::autosign,
   String  $docker_group   = $puppetfactory::params::docker_group,   # why are some of these items configurable?
+  String  $stagedir       = $puppetfactory::params::stagedir,       # unfortunately $stagedir is not in $settings...
 
   String  $confdir        = $settings::confdir,
   String  $codedir        = $settings::codedir,
@@ -66,12 +67,6 @@ class puppetfactory (
   }
   else {
     $real_gitserver = pick($gitserver, 'https://github.com')
-  }
-
-  if 'CodeManager' in $plugins {
-    $stagedir = '/etc/puppetlabs/code-staging'
-  } else {
-    $stagedir = '/etc/puppetlabs/code'
   }
 
   class { 'abalone':

--- a/pltraining-puppetfactory/manifests/params.pp
+++ b/pltraining-puppetfactory/manifests/params.pp
@@ -5,6 +5,9 @@ class puppetfactory::params {
     default => $::os['selinux']['enabled'],
   }
 
+  # for whatever reason, CodeManager/FileSync settings aren't available in $settings
+  $stagedir = '/etc/puppetlabs/code-staging'
+
   $autosign      = false
   $manage_gitlab = false
   $docker_group  = 'docker'


### PR DESCRIPTION
Even when editing code in ~/puppetcode, this enforces the need to
actively choose to deploy your codebase. This will copy all the code
from the user's environment in code-staging to codedir, make sure that
it's owned by 'pe-puppet', and then clear the environment cache.

This is marked WIP only because I'd like to test it more. Feel free to
unmark it and merge if you do the necessary testing.

TRAINTECH-896 #resolved #time 3h