### PR TITLE
don't deploy if editing code live

### DIFF
--- a/puppetfactory/lib/puppetfactory/plugins/user_environment.rb
+++ b/puppetfactory/lib/puppetfactory/plugins/user_environment.rb
@@ -60,6 +60,8 @@ class Puppetfactory::Plugins::UserEnvironment < Puppetfactory::Plugins
   end
 
   def deploy(username)
+    # TODO: temporary hack to keep this from disrupting current deliveries.
+    return if @codestage == @environments
     environment = Puppetfactory::Helpers.environment_name(username)
 
     FileUtils.cp_r("#{@codestage}/#{environment}/.", "#{@environments}/#{environment}")


### PR DESCRIPTION
This is gross. But it will keep deliveries this week from failing. Next week we can roll out the tested deploy workflow and update the materials to match.