### PR TITLE
Stop automatically applying course selector

### DIFF
--- a/pltraining-puppetfactory/templates/centos.dockerfile.erb
+++ b/pltraining-puppetfactory/templates/centos.dockerfile.erb
@@ -12,8 +12,8 @@ ADD mirror /var/yum/mirror
 RUN yum -y install sudo tar dmidecode which logrotate cyrus-sasl libxslt cronie pciutils git rubygems vim tree csh zsh ntpdate postfix lynx wget openssl-libs
 RUN rm -rf /var/yum/mirror
 ADD vimrc /root/.vimrc
-RUN echo 'if ! hash puppet; then curl -k https://<%= @puppetmaster %>:8140/packages/current/install.bash | sudo bash; puppet apply -e "include course_selector"; fi' >> /root/.bashrc
 RUN mkdir -p /etc/puppetlabs/code/modules
+RUN echo 'if ! hash puppet; then curl -k https://<%= @puppetmaster %>:8140/packages/current/install.bash | sudo bash; puppet module install pltraining-userprefs --modulepath=/etc/puppetlabs/code/modules; fi' >> /root/.bashrc
 RUN git clone https://github.com/puppetlabs/pltraining-course_selector /etc/puppetlabs/code/modules/course_selector
 EXPOSE 3306 80
 CMD ["/sbin/init"]


### PR DESCRIPTION
Stop using the course selector tool. This goes with another PR to courseware-virtual which changes the instructions to use puppet apply.
This also installs the userprefs module locally since that's used by some of the course selector profiles.