### PR TITLE
Puppetclassify needs this set to even initialize

### DIFF
--- a/puppetfactory/bin/pfsh
+++ b/puppetfactory/bin/pfsh
@@ -13,6 +13,7 @@ end
 options[:plugins] ||= [:LoginShell]
 options[:logfile] ||= STDOUT
 options[:session] ||= '12345'
+options[:master]  ||= `hostname -f`.strip
 
 $logger = Logger.new(options[:logfile])
 


### PR DESCRIPTION
See TRAINTECH-1162

copied from the ticket:

> This change in puppetclassify caused the behavior change: https://github.com/puppetlabs/puppet-classify/pull/18