### PR TITLE
Prevent view from wrapping on smaller screens

### DIFF
--- a/public/explain-git-with-d3/css/explaingit.css
+++ b/public/explain-git-with-d3/css/explaingit.css
@@ -9,6 +9,7 @@ p {
 
 .container {
   padding: 0;
+  min-width: 1150px;
 }
 
 #menuwrapper {


### PR DESCRIPTION
Especially when embedded on a Puppetfactory tab, this has the tendency to wrap and make the graph disappear when the screen is too small. This prevents the bounding box from shrinking that far. Scroll bars are preferable to invisible elements.

COURSES-2188 #resolved #time 30m