### PR TITLE
(MAINT) Fix Admin Login Redirect Error

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -113,8 +113,10 @@ tr:nth-child(2n+2) {
 }
 
 #login {
+  float: right;
   color: transparent;
   background-color: transparent;
+  margin: 1.2em 2em;
 }
 
 #userslist,

--- a/views/index.erb
+++ b/views/index.erb
@@ -21,10 +21,8 @@
         <% @tabs.each do |url, title| %>
           <li><a href="/<%= url %>"><%= title %></a></li>
         <% end %>
-        <li class="right">
-          <% unless privileged? %><a href="/login" id="login">Admin Login</a><% end %>
-        </li>
       </ul>
+      <% unless privileged? %><a href="/login" id="login">Admin Login</a><% end %>
     </header>
     <article>
       <h1>Puppet Training Classroom Manager</h1>


### PR DESCRIPTION
Moved the admin login link out of the JqueryUI tabs.  It was
 causing an infinite reload loop because of how it interacts with
 the Sinatra redirect and the JqueryUI remote loading.