### PR TITLE
(MAINT) Move logger to tmp for permissions reasons

### DIFF
--- a/bin/puppetfactory
+++ b/bin/puppetfactory
@@ -63,7 +63,7 @@ options[:stagedir]     ||= '/etc/puppetlabs/code-staging'
 options[:environments] ||= "#{options[:codedir]}/environments"
 
 options[:root]         ||= File.expand_path(File.join(File.dirname(__FILE__), '..'))
-options[:logfile]      ||= '/var/log/puppetfactory'
+options[:logfile]      ||= '/tmp/puppetfactory'
 options[:templatedir]  ||= "#{File.dirname(__FILE__)}/../templates"
 
 options[:port]         ||= 8000


### PR DESCRIPTION
The /var directory often requires root permissions that cannot be
 relied on running this outside of controlled vms.  Moving to /tmp
 makes this more reliable.