### PR TITLE
Map directories for yum cache

### DIFF
--- a/lib/puppetfactory/plugins/docker.rb
+++ b/lib/puppetfactory/plugins/docker.rb
@@ -29,10 +29,12 @@ class Puppetfactory::Plugins::Docker < Puppetfactory::Plugins
   def create(username, password)
     begin
       environment = "#{@environments}/#{Puppetfactory::Helpers.environment_name(username)}"
-
       binds = [
         "/var/yum:/var/yum",
-        "/var/cache/rubygems:/var/cache/rubygems",
+        "/var/cache:/var/cache",
+        "/etc/pki/rpm-gpg:/etc/pki/rpm-gpg",
+        "/etc/yum.repos.d:/etc/yum.repos.d",
+        "/opt/puppetlabs/server:/opt/puppetlabs/server",
         "/home/#{username}/puppet:#{@confdir}",
         "/sys/fs/cgroup:/sys/fs/cgroup:ro"
       ]


### PR DESCRIPTION
This adds some additional mounts within the containers to provide more
yum repo caching. If the directory doesn't exist on the master, docker
will just create it, so this should be backwards compatible