### PR TITLE
(TRAINTECH-1302) Resolve Session Refresh Bug

### DIFF
--- a/lib/puppetfactory.rb
+++ b/lib/puppetfactory.rb
@@ -26,7 +26,11 @@ class Puppetfactory < Sinatra::Base
 
   configure :production, :development do
     enable :logging
-    enable :sessions
+    use Rack::Session::Cookie, 
+      :key => 'puppetfactory.session',
+      :path => '/',
+      :expire_after => 2592000, # In seconds
+      :secret => 'some_secret'
   end
 
   def initialize(app=nil)

--- a/lib/puppetfactory.rb
+++ b/lib/puppetfactory.rb
@@ -27,10 +27,10 @@ class Puppetfactory < Sinatra::Base
   configure :production, :development do
     enable :logging
     use Rack::Session::Cookie, 
-      :key => 'puppetfactory.session',
-      :path => '/',
+      :key          => 'puppetfactory.session',
+      :path         => '/',
       :expire_after => 2592000, # In seconds
-      :secret => 'some_secret'
+      :secret       => 'some_secret'
   end
 
   def initialize(app=nil)


### PR DESCRIPTION
TRAINTECH-1302 #resolved #time 5d
Since both Puppetfactory and Abalone are Sinatra apps, whenever
 the shell page was refreshed, their sessions conflicted.  This
 specifies the session.key to prevent collision.