### PR TITLE
Disable caching

### DIFF
--- a/lib/puppetfactory.rb
+++ b/lib/puppetfactory.rb
@@ -33,6 +33,11 @@ class Puppetfactory < Sinatra::Base
       :secret       => 'some_secret'
   end
 
+  before do
+    # IE is cache happy. Let's make that go away.
+    cache_control :no_cache, :max_age => 0
+  end
+  
   def initialize(app=nil)
     super(app)
 


### PR DESCRIPTION
Because IE over caches content, it would never reload the user page when you selected a user. This fixes that.

TRAINTECH-1219 #resolved #time 2h