### PR TITLE
(maint) This enables a login action by default

### DIFF
--- a/bin/puppetfactory
+++ b/bin/puppetfactory
@@ -85,7 +85,7 @@ options[:gituser]      ||= 'puppetlabs'
 options[:controlrepo]  ||= 'control-repo.git'
 options[:repomodel]    ||= :single
 
-options[:plugins]      ||= [:ShellUser, :Logs]
+options[:plugins]      ||= [:ShellUser, :Logs, :LoginShell]
 
 def validate(options, option, values)
   unless values.include? options[option]


### PR DESCRIPTION
With this commit, the default configuration doesn't provide a way for
users to log in. We never noticed, because we never run in the default
configuration.