### PR TITLE
Increase Thin timeout

### DIFF
--- a/bin/puppetfactory
+++ b/bin/puppetfactory
@@ -106,7 +106,10 @@ $logger.formatter = proc { |severity,datetime,progname,msg| "[#{datetime}] #{sev
 
 # if no arguments, start up the server
 if ARGV.size == 0
- Puppetfactory.run! options
+  # TODO: remove this insane timeout once we have a progressive user creation dialog
+  Puppetfactory.run!(options) do |server|
+    server.timeout = 180
+  end
 
 #   opts = {
 #           :Port               => 8000,


### PR DESCRIPTION
The Thin middleware server was timing out (30s by default) when the
classroom got loaded down. This caused the user creation to sometimes be
incomplete, and would lead to a poor user experience when they got raw
HTML squished into a popup dialog box!

The better solution is a progress bar, but that's out of scope for the
current sprint.

TRAINTECH-1392 #resolved #time 6h