### PR TITLE
Reload the page on user creation

### DIFF
--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -26,5 +26,11 @@ function updatePage(name) {
     var idx = $("#tabs").tabs("option","active");
   }
 
-  $("#tabs").tabs('load', idx);
+  // force a hard reload if we're already on the desired page
+  if ($("#tabs").tabs("option","active") == idx) {
+    location.reload(true);
+  }
+  else {
+    $("#tabs").tabs('load', idx);
+  }
 }


### PR DESCRIPTION
jQuery doesn't reload a page when you switch to it unless needed. If
you're already on the desired page, it doesn't do anything.

TRAINTECH-1390 #resolved #time 15m