### PR TITLE
(maint) Ensure that the admin's .ssh directory exists

### DIFF
--- a/lib/puppetfactory/plugins/gitea.rb
+++ b/lib/puppetfactory/plugins/gitea.rb
@@ -20,6 +20,9 @@ class Puppetfactory::Plugins::Gitea < Puppetfactory::Plugins
     @gitea_port     = options[:gitea_port]           || '3000'
     @gitea_user     = options[:gitea_user]           || 'git'
     @gitea_homedir  = Dir.home(@gitea_user)
+    
+    # gitea will scream if the admin's .ssh directory doesn't exist
+    FileUtils.mkdir_p(File.expand_path("~#{@admin_username}/.ssh"))
 
     migrate_repo! unless File.directory?(@cache_dir)
   end


### PR DESCRIPTION
If the admin's `~/.ssh` directory doesn't exist, then the `gitea` process will stack trace the first time you try to create a new user.