### PR TITLE
This prevents initialization from running as users

### DIFF
--- a/lib/puppetfactory/plugins/dashboard.rb
+++ b/lib/puppetfactory/plugins/dashboard.rb
@@ -16,7 +16,7 @@ class Puppetfactory::Plugins::Dashboard < Puppetfactory::Plugins
     @current_test = 'summary'
     @test_running = false
 
-    start_testing()
+    start_testing() if Process.euid == 0
 
     @server.get '/dashboard' do
       protected!

--- a/lib/puppetfactory/plugins/gitea.rb
+++ b/lib/puppetfactory/plugins/gitea.rb
@@ -20,7 +20,10 @@ class Puppetfactory::Plugins::Gitea < Puppetfactory::Plugins
     @gitea_port     = options[:gitea_port]           || '3000'
     @gitea_user     = options[:gitea_user]           || 'git'
     @gitea_homedir  = Dir.home(@gitea_user)
-    
+
+    # the rest of this method is for the big boys only
+    return unless Process.euid == 0
+
     # gitea will scream if the admin's .ssh directory doesn't exist
     FileUtils.mkdir_p(File.expand_path("~#{@admin_username}/.ssh"))
 


### PR DESCRIPTION
Code that should only be run during the server startup is now better
gated. This will prevent the permission error during user logins.

TRAINTECH-1420 #resolved #time 30m