### PR TITLE
Prevent header wrapping

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -47,6 +47,8 @@ code {
 header {
   height: 4em;
   top: 0;
+  overflow-x: scroll;
+  white-space: nowrap;
 }
 
 header ul,
@@ -157,7 +159,7 @@ input.fail {
 }
 
 .tab.active {
-  background: #ECEFF1;  
+  background: #ECEFF1;
 }
 
 .tab-content {


### PR DESCRIPTION
This isn't truly a full solution because items that fall off if the
window is too narrow just disappear. A longer term solution would be to
be more responsive. But this is a good step to prevent the ugly
wrapping.

TRAINTECH-1463 #resolved #time 20m